### PR TITLE
Fixes #7.

### DIFF
--- a/src/xunit.runner.xamarin/Utilities/FilteredCollectionView.cs
+++ b/src/xunit.runner.xamarin/Utilities/FilteredCollectionView.cs
@@ -66,26 +66,17 @@ namespace Xunit.Runners.Utilities
 
         private void RefreshFilter()
         {
+            this.filteredList.Clear();
+
             foreach (var item in this.dataSource)
             {
-                int index = this.filteredList.IndexOf(item);
                 if (this.filter(item, this.filterArgument))
                 {
-                    if (index < 0)
-                    {
-                        this.filteredList.Insert(~index, item);
-                        this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, ~index));
-                    }
-                }
-                else
-                {
-                    if (index >= 0)
-                    {
-                        this.filteredList.RemoveAt(index);
-                        this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
-                    }
+                    this.filteredList.Add(item);
                 }
             }
+
+            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         private void dataSource_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
This PR fixes #7 by:

1. Only instigating filtering after the user finishes typing for 500ms. This means that when typing a word at a reasonable pace, only one search will be instigated.
2. When filtering, clearing all results and resetting the collection instead of adding/removing individual items. This results in much faster searches and bypasses the exception that was popping up time-to-time with the prior approach.