### PR TITLE
Fixes #9.

### DIFF
--- a/src/xunit.runner.xamarin/ViewModels/TestResultViewModel.cs
+++ b/src/xunit.runner.xamarin/ViewModels/TestResultViewModel.cs
@@ -40,7 +40,13 @@ namespace Xunit.Runners
         public TimeSpan Duration
         {
             get { return duration; }
-            set { Set(ref duration, value); }
+            set 
+            {
+                if (Set(ref duration, value) && testCase != null)
+                {
+                    testCase.UpdateTestState(this);
+                }
+            }
         }
 
         public string ErrorMessage


### PR DESCRIPTION
This PR fixes #9 by ensuring that a change to the `TestResultViewModel.Duration` property results in any associated `TestCaseViewModel` updating its test state.

Frankly, I think it's likely possible to overhaul these VMs quite a bit, but I didn't want to head down a rabbit hole. This seems like a pragmatic solution to me.