### PR TITLE
Fixes #11

### DIFF
--- a/src/xunit.runner.xamarin/ViewModels/TestAssemblyViewModel.cs
+++ b/src/xunit.runner.xamarin/ViewModels/TestAssemblyViewModel.cs
@@ -146,7 +146,7 @@ namespace Xunit.Runners.ViewModels
             }
 
             var pattern = query.Item1;
-            return string.IsNullOrWhiteSpace(pattern) || test.DisplayName.IndexOf(pattern.Trim(), StringComparison.OrdinalIgnoreCase) >= 0;
+            return string.IsNullOrWhiteSpace(pattern) || test.UniqueName.IndexOf(pattern.Trim(), StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         public string SearchQuery


### PR DESCRIPTION
This PR fixes #11 by filtering against the test's `UniqueName` rather than its `DisplayName`. Since the unique name includes the fixture name, this makes it possible to filter by the fixture.