### PR TITLE
Fixes #13.

### DIFF
--- a/src/xunit.runner.xamarin/Pages/AssemblyTestListPage.xaml
+++ b/src/xunit.runner.xamarin/Pages/AssemblyTestListPage.xaml
@@ -33,7 +33,8 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-            <Button Text="Run All" Command="{Binding RunTestsCommand}" />
+            <Button Text="Run Filtered" Command="{Binding RunFilteredTestsCommand}" />
+            <Button Text="Run All" Command="{Binding RunAllTestsCommand}" />
         </StackLayout>
         <ActivityIndicator Grid.Row="0"  VerticalOptions="Start" IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}"  />
     </Grid>

--- a/src/xunit.runner.xamarin/ViewModels/TestAssemblyViewModel.cs
+++ b/src/xunit.runner.xamarin/ViewModels/TestAssemblyViewModel.cs
@@ -16,6 +16,8 @@ namespace Xunit.Runners.ViewModels
     {
         private readonly INavigation navigation;
         private readonly ITestRunner runner;
+        private readonly Command runAllTestsCommand;
+        private readonly Command runFilteredTestsCommand;
         private string detailText;
         private Color displayColor;
         private string displayName;
@@ -31,7 +33,8 @@ namespace Xunit.Runners.ViewModels
             this.navigation = navigation;
             this.runner = runner;
 
-            RunTestsCommand = new Command(RunTests);
+            runAllTestsCommand = new Command(RunAllTests, () => !isBusy);
+            runFilteredTestsCommand = new Command(RunFilteredTests, () => !isBusy);
 
             DisplayName = Path.GetFileNameWithoutExtension(@group.Key);
 
@@ -176,7 +179,14 @@ namespace Xunit.Runners.ViewModels
         public bool IsBusy
         {
             get { return isBusy; }
-            private set { Set(ref isBusy, value); }
+            private set 
+            {
+                if (Set(ref isBusy, value))
+                {
+                    this.runAllTestsCommand.ChangeCanExecute();
+                    this.runFilteredTestsCommand.ChangeCanExecute();
+                }
+            }
         }
 
         public TestState Result
@@ -209,14 +219,35 @@ namespace Xunit.Runners.ViewModels
             get { return filteredTests; }
         }
 
-        public ICommand RunTestsCommand { get; private set; }
+        public ICommand RunAllTestsCommand
+        {
+            get { return runAllTestsCommand; }
+        }
 
-        private async void RunTests()
+        public ICommand RunFilteredTestsCommand
+        {
+            get { return runFilteredTestsCommand; }
+        }
+
+        private async void RunAllTests()
         {
             try
             {
                 IsBusy = true;
                 await runner.Run(allTests);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async void RunFilteredTests()
+        {
+            try
+            {
+                IsBusy = true;
+                await runner.Run(filteredTests);
             }
             finally
             {


### PR DESCRIPTION
This PR fixes #13 by adding another button (**Run Filtered**) that executes only those tests that are currently filtered.

I also took the liberty to change the commands so that they are disabled whilst tests are executing. Note, however, that the **Run Everything** command on the home page does not yet respect this, presumably because of a Xamarin Forms limitation. I left the `HomeViewModel.cs` code in anyway because it is more consistent and because it will work properly if/when the `TextCell` class respects the `CanExecute` status of the command.