### PR TITLE
Fix typo in nuspec

### DIFF
--- a/src/xunit.runner.xamarin.nuspec
+++ b/src/xunit.runner.xamarin.nuspec
@@ -72,7 +72,7 @@
     <file src="xunit.runner.ios\bin\iPhone\Release\xunit.runner.xamarin.xml" target="lib\MonoTouch\xunit.runner.xamarin.xml" />
     
     <file src="build\xunit.runner.xamarin.targets" target="build\Xamarin.iOS\xunit.runner.xamarin.targets" />
-    <file src="xunit.runner.ios-unified\bin\iPhone\Release\xunit.runner.xamarin.dll" target="lib\Xamarin.iOS\xunit.runner.xamarind.dll" />
+    <file src="xunit.runner.ios-unified\bin\iPhone\Release\xunit.runner.xamarin.dll" target="lib\Xamarin.iOS\xunit.runner.xamarin.dll" />
     <file src="xunit.runner.ios-unified\bin\iPhone\Release\xunit.runner.xamarin.pdb" target="lib\Xamarin.iOS\xunit.runner.xamarin.pdb" />
     <file src="xunit.runner.ios-unified\bin\iPhone\Release\xunit.runner.xamarin.xml" target="lib\Xamarin.iOS\xunit.runner.xamarin.xml" />
 


### PR DESCRIPTION
This typo introduces an error where it cannot find the Assembly and complains about "AppDelegate" not being found.